### PR TITLE
feat: add claude.md with German language configuration

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,26 @@
+# Claude Konfiguration
+
+## Spracheinstellungen
+
+**WICHTIG: Claude soll ausschließlich auf Deutsch antworten.**
+
+- Alle Antworten, Code-Kommentare und Erklärungen müssen auf Deutsch verfasst werden
+- Deutsche Terminologie für technische Begriffe verwenden, wo sinnvoll
+- Bei Code-Reviews und technischen Diskussionen deutsche Fachsprache nutzen
+- Commit-Messages können auf Englisch bleiben (Standard in der Softwareentwicklung)
+
+## Projektspezifische Richtlinien
+
+Dieses Projekt ist eine Astro-basierte Website. Bei der Arbeit mit diesem Repository:
+
+- Astro-Konventionen befolgen
+- TypeScript für alle neuen Dateien verwenden
+- Tailwind CSS für Styling nutzen
+- Tests mit Vitest und Playwright ausführen
+
+## Kommunikationsrichtlinien
+
+- Höflich und professionell kommunizieren
+- Kurze, präzise Antworten geben
+- Bei komplexen Aufgaben Schritt-für-Schritt-Erklärungen liefern
+- Code-Beispiele mit deutschen Kommentaren versehen


### PR DESCRIPTION
Adds claude.md file to configure Claude to respond exclusively in German.

Closes #102

Generated with [Claude Code](https://claude.ai/code)