### PR TITLE
docs: Add clarification for English GitHub keywords in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,13 @@ npm run prettier   # Code-Formatierung prüfen
 - Format: `type(scope): description`
 - Typen: feat, fix, docs, style, refactor, test, chore
 
+### GitHub-Keywords:
+**⚠️ WICHTIG: GitHub-Keywords MÜSSEN auf Englisch bleiben!**
+- Keywords wie `fix`, `fixes`, `close`, `closes`, `resolve`, `resolves` für automatisches Issue-Schließen
+- Diese Keywords funktionieren nur auf Englisch und sollten NICHT übersetzt werden
+- Beispiel: `fix: Update navigation (#123)` - "fix" bleibt Englisch
+- In PR-Beschreibungen: `Closes #123` - nicht "Schließt #123"
+
 ### Branch-Namen:
 - Feature: `feature/beschreibung`
 - Bugfix: `fix/beschreibung`


### PR DESCRIPTION
Closes #114

## Summary
Klarstellung hinzugefügt, dass GitHub-Keywords (fix, closes, etc.) auf Englisch bleiben müssen, damit sie funktionieren.

Generated with [Claude Code](https://claude.ai/code)