### PR TITLE
fix: Korrigiere Startzeit Vortrag Schlafstörungen auf 15:00 Uhr

### DIFF
--- a/src/content/events/2025-10-15-vortrag-schlafstoerungen.md
+++ b/src/content/events/2025-10-15-vortrag-schlafstoerungen.md
@@ -1,6 +1,6 @@
 ---
-startDate: 2025-10-15T19:00:00+02:00
-endDate: 2025-10-15T21:00:00+02:00
+startDate: 2025-10-15T15:00:00+02:00
+endDate: 2025-10-15T17:00:00+02:00
 location: dgh
 organizer: drk
 description:


### PR DESCRIPTION
Ändere Vortragsbeginn von 19:00 auf 15:00 Uhr und Ende von 21:00 auf 17:00 Uhr (Dauer: 2 Stunden).

Fixes #123

Generated with [Claude Code](https://claude.ai/code)