### PR TITLE
Fix broken event links routing issue

### DIFF
--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -23,7 +23,7 @@ const time = getTime(startDate)
 
 <a
   class="card card-compact bg-base-100 shadow-md hover:shadow-xl transition-all duration-300 h-full group"
-  href={event.data.url ?? `events/${event.id}`}
+  href={event.data.url ?? `/events/${event.id}`}
   target={target}
 >
   {


### PR DESCRIPTION
Die Event-Links waren relativ (events/${event.id}), was auf der /events-Seite zu doppelten Pfaden wie /events/events/... führte. Jetzt wird ein absoluter Pfad (/events/${event.id}) verwendet.