### PR TITLE
Audit sitemap and fix mismatches

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,7 +13,7 @@ import { defineConfig } from 'astro/config'
 export default defineConfig({
   site:
     process.env.VERCEL_ENV === 'production'
-      ? `https://${process.env.VERCEL_URL}`
+      ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
       : process.env.VERCEL_ENV === 'preview'
         ? `https://${process.env.VERCEL_BRANCH_URL}`
         : 'http://localhost:4321',


### PR DESCRIPTION
VERCEL_URL enthält die Deployment-URL, nicht die Custom Domain. VERCEL_PROJECT_PRODUCTION_URL enthält die konfigurierte Production-Domain.