### PR TITLE
feat(events): Bürgermahl der Bürgerstiftung am 7. Februar 2026 hinzugefügt

### DIFF
--- a/src/content/events/2026-02-07-buergermahl-buergerstiftung.md
+++ b/src/content/events/2026-02-07-buergermahl-buergerstiftung.md
@@ -7,7 +7,7 @@ description:
 name: Bürgermahl
 ---
 
-Das Bürgermahl der Bürgerstiftung Rössing findet im Restaurant „Alt Rössing" statt.
+Das Bürgermahl der Bürgerstiftung Rössing findet im Gasthaus „Alt-Rössing am Schlosspark" statt.
 
 ## Programm
 

--- a/src/data/locations/alt-roessing.yaml
+++ b/src/data/locations/alt-roessing.yaml
@@ -1,7 +1,7 @@
-name: Restaurant Alt Rössing
+name: Gasthaus "Alt-Rössing am Schlosspark"
 address:
   '@type': PostalAddress
-  streetAddress: Hauptstraße 7
-  addressLocality: Rössing
+  streetAddress: Unter den Eichen 1A
+  addressLocality: Nordstemmen
   postalCode: '31171'
 '@type': Place


### PR DESCRIPTION
Fixes #165

## Zusammenfassung

- Neuer Termin für das Bürgermahl der Bürgerstiftung Rössing am 7. Februar 2026
- Neue Location "Alt Rössing" hinzugefügt

## Test plan

- [ ] Überprüfen, ob der Termin auf der Events-Seite angezeigt wird

🤖 Generated with [Claude Code](https://claude.ai/code)