### PR TITLE
feat: Frühlingsfest der SPD am 24. April hinzufügen

### DIFF
--- a/src/content/events/2026-04-24-fruehlingsfest-spd.md
+++ b/src/content/events/2026-04-24-fruehlingsfest-spd.md
@@ -1,0 +1,12 @@
+---
+startDate: 2026-04-24T18:00:00+02:00
+location: dgh
+organizer: spd
+description:
+  Frühlingsfest der SPD im Dorfgemeinschaftshaus Rössing.
+name: Frühlingsfest der SPD
+---
+
+Die SPD Rössing-Barnten lädt herzlich zum Frühlingsfest ins Dorfgemeinschaftshaus Rössing ein.
+
+Alle Interessierten sind herzlich willkommen.


### PR DESCRIPTION
## Zusammenfassung

- Event für das Frühlingsfest der SPD am 24. April 2026 um 18:00 Uhr hinzugefügt
- Veranstaltungsort: Dorfgemeinschaftshaus (DGH)
- Veranstalter: SPD Rössing-Barnten

Fixes #201

---
Generated with [Claude Code](https://claude.ai/code)