### PR TITLE
Konzert KADINLAR SESİ am 29.04.2026 hinzufügen

### DIFF
--- a/src/content/events/2026-04-29-kadinlar-sesi.md
+++ b/src/content/events/2026-04-29-kadinlar-sesi.md
@@ -1,0 +1,17 @@
+---
+name: KADINLAR SESİ – Lieder ohne Grenzen
+description: Konzert mit Bettina Braun, Danuta Busse und Elif Alkaç in der Rössinger Kirche. Drei Frauenstimmen, Gitarre und Akkordeon – ein Zusammenkommen in Musik. Eintritt frei, um Spenden wird gebeten.
+startDate: 2026-04-29T18:00:00+02:00
+location: kirche
+organizer: kulturkreis
+---
+
+**KADINLAR SESİ – Lieder ohne Grenzen**
+
+Drei Frauenstimmen, Gitarre und Akkordeon – akustisch, handgemacht, zwischen Melancholie und Leichtigkeit.
+
+Mit **Bettina Braun**, **Danuta Busse** und **Elif Alkaç**.
+
+Ein Zusammenkommen in Musik in der Rössinger Kirche.
+
+Eintritt kostenlos – um Spenden wird gebeten.


### PR DESCRIPTION
## Zusammenfassung

- Neues Event: **KADINLAR SESİ – Lieder ohne Grenzen** am 29. April 2026 um 18:00 Uhr
- Ort: Rössinger Kirche (St. Peter und Paul)
- Künstlerinnen: Bettina Braun, Danuta Busse, Elif Alkaç
- Drei Frauenstimmen, Gitarre und Akkordeon
- Eintritt kostenlos, um Spenden wird gebeten

## Testplan

- [ ] Build erfolgreich (bereits lokal verifiziert)
- [ ] Event erscheint korrekt auf der Veranstaltungsseite
- [ ] Event-Detailseite zeigt alle Informationen an

https://claude.ai/code/session_01P12VwYiTwGBsak9tk76PPW