### PR TITLE
Veranstalter von KADINLAR SESİ auf Kirche korrigieren

### DIFF
--- a/src/content/events/2026-04-29-kadinlar-sesi.md
+++ b/src/content/events/2026-04-29-kadinlar-sesi.md
@@ -3,7 +3,7 @@ name: KADINLAR SESİ – Lieder ohne Grenzen
 description: Konzert mit Bettina Braun, Danuta Busse und Elif Alkaç in der Rössinger Kirche. Drei Frauenstimmen, Gitarre und Akkordeon – ein Zusammenkommen in Musik. Eintritt frei, um Spenden wird gebeten.
 startDate: 2026-04-29T18:00:00+02:00
 location: kirche
-organizer: kulturkreis
+organizer: kirche
 ---
 
 **KADINLAR SESİ – Lieder ohne Grenzen**


### PR DESCRIPTION
## Zusammenfassung

- Korrigiert den Veranstalter des Konzerts **KADINLAR SESİ – Lieder ohne Grenzen** am 29.04.2026
- Veranstalter ist die Kirche, nicht der Kulturkreis

## Testplan

- [ ] Event-Detailseite zeigt die Kirche als Veranstalter an

https://claude.ai/code/session_01P12VwYiTwGBsak9tk76PPW