### PR TITLE
feat(events): Mini-Sportabzeichen-Nachmittag am 16.04.2026

### DIFF
--- a/src/content/events/2026-04-16-mini-sportabzeichen-vsv.md
+++ b/src/content/events/2026-04-16-mini-sportabzeichen-vsv.md
@@ -1,0 +1,22 @@
+---
+startDate: 2026-04-16T15:00:00+02:00
+endDate: 2026-04-16T17:00:00+02:00
+location: stubenrauchhalle
+organizer: vsv
+description: Der VSV lädt Kinder von 3 bis 6 Jahren zum Mini-Sportabzeichen-Nachmittag mit Hoppel und Bürste ein.
+name: Mini-Sportabzeichen-Nachmittag
+---
+
+Der VSV Rössing lädt ein zum Mini-Sportabzeichen-Nachmittag mit Hoppel und Bürste!
+
+Hilf Hoppel und Bürste auf ihrem Weg zum Geburtstag von Frau Eule, indem du mit ihnen läufst, hüpfst und balancierst! An sechs Stationen kannst du dabei zeigen, wie sportlich du schon bist – und am Ende nimmst du dein Mini-Sportabzeichen mit nach Hause.
+
+## Details
+
+- **Wann:** Donnerstag, 16. April 2026, 15:00 - 17:00 Uhr
+- **Wo:** Alfred-Stubenrauch-Halle, Loderwinkel 2a
+- **Wer:** Kinder im Alter von 3 bis 6 Jahren
+
+Eine Vereinsmitgliedschaft ist nicht notwendig!
+
+Wir freuen uns auf dich!


### PR DESCRIPTION
## Zusammenfassung
- Neue Event-Datei für den Mini-Sportabzeichen-Nachmittag vom VSV Rössing
- Datum: 16. April 2026, 15:00 - 17:00 Uhr
- Ort: Alfred-Stubenrauch-Halle
- Zielgruppe: Kinder von 3 bis 6 Jahren

Closes #205

Generated with [Claude Code](https://claude.ai/code)