### PR TITLE
Add event shortlink system with auto-generation and redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import shipyard from '@levino/shipyard-base'
 import shipyardDocs from '@levino/shipyard-docs'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
+import eventShortlinks from './src/integrations/event-shortlinks.ts'
 
 const branch = process.env.WORKERS_CI_BRANCH
 
@@ -60,6 +61,7 @@ export default defineConfig({
       ],
     }),
     shipyardDocs(),
+    eventShortlinks(),
   ],
   vite: {
     plugins: [tailwindcss()],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cypress:run": "cypress run",
     "e2e": "playwright test",
     "format": "biome check --write .",
+    "shortlink": "node scripts/assign-event-shortlink.js",
     "claude": "claude --dangerously-skip-permissions"
   },
   "dependencies": {

--- a/scripts/assign-event-shortlink.js
+++ b/scripts/assign-event-shortlink.js
@@ -8,6 +8,34 @@ const EVENTS_DIR = join(process.cwd(), 'src/content/events')
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
 const SHORTLINK_REGEX = /^shortlink:\s*([a-z0-9]{3})\s*$/m
 
+// 3-Zeichen-Codes, die wegen NS-/extremistischer/vulgaerer Lesart nicht
+// zufaellig vergeben werden sollen. Manuell setzen ist weiterhin moeglich.
+const BLOCKED_CODES = new Set([
+  'nzs',
+  'naz',
+  'nzi',
+  'nsd',
+  'kkk',
+  'afd',
+  'npd',
+  'raf',
+  'sex',
+  'fck',
+  'fuk',
+  'fuc',
+  'ass',
+  'tit',
+  'cum',
+  'pus',
+  'fag',
+  'nig',
+  'jew',
+])
+
+// Zusaetzlich werden Codes blockiert, die "ss" enthalten – im deutschen
+// Kontext zu naheliegend an die NS-Schutzstaffel.
+const containsBlockedSubstring = (code) => code.includes('ss')
+
 const target = process.argv[2]
 if (!target) {
   console.error(
@@ -53,9 +81,14 @@ const generate = () => {
   return code
 }
 
+const isAcceptable = (code) =>
+  !taken.has(code) &&
+  !BLOCKED_CODES.has(code) &&
+  !containsBlockedSubstring(code)
+
 let code = generate()
 let attempts = 0
-while (taken.has(code)) {
+while (!isAcceptable(code)) {
   code = generate()
   attempts += 1
   if (attempts > 1000) {

--- a/scripts/assign-event-shortlink.js
+++ b/scripts/assign-event-shortlink.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { randomInt } from 'node:crypto'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const EVENTS_DIR = join(process.cwd(), 'src/content/events')
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789'
+const SHORTLINK_REGEX = /^shortlink:\s*([a-z0-9]{3})\s*$/m
+
+const target = process.argv[2]
+if (!target) {
+  console.error(
+    'Verwendung: node scripts/assign-event-shortlink.js <event-dateiname>',
+  )
+  process.exit(1)
+}
+
+const allFiles = readdirSync(EVENTS_DIR).filter(
+  (f) => !f.startsWith('_') && (f.endsWith('.md') || f.endsWith('.mdx')),
+)
+
+const targetFile = allFiles.find(
+  (f) => f === target || f === `${target}.md` || f === `${target}.mdx`,
+)
+if (!targetFile) {
+  console.error(`Event-Datei "${target}" nicht gefunden in ${EVENTS_DIR}.`)
+  process.exit(1)
+}
+
+const targetPath = join(EVENTS_DIR, targetFile)
+const targetRaw = readFileSync(targetPath, 'utf-8')
+const existing = targetRaw.match(SHORTLINK_REGEX)
+if (existing) {
+  console.log(
+    `Event "${targetFile}" hat bereits den shortlink "${existing[1]}". Nichts zu tun.`,
+  )
+  process.exit(0)
+}
+
+const taken = new Set()
+for (const file of allFiles) {
+  const raw = readFileSync(join(EVENTS_DIR, file), 'utf-8')
+  const match = raw.match(SHORTLINK_REGEX)
+  if (match) taken.add(match[1])
+}
+
+const generate = () => {
+  let code = ''
+  for (let i = 0; i < 3; i += 1) {
+    code += ALPHABET[randomInt(ALPHABET.length)]
+  }
+  return code
+}
+
+let code = generate()
+let attempts = 0
+while (taken.has(code)) {
+  code = generate()
+  attempts += 1
+  if (attempts > 1000) {
+    console.error('Konnte keinen freien shortlink finden.')
+    process.exit(1)
+  }
+}
+
+const updated = targetRaw.replace(
+  /^(---\r?\n[\s\S]*?)(\r?\n---\r?\n?)/,
+  `$1\nshortlink: ${code}$2`,
+)
+
+if (updated === targetRaw) {
+  console.error(
+    `Konnte Frontmatter-Block in "${targetFile}" nicht erkennen. Datei nicht verändert.`,
+  )
+  process.exit(1)
+}
+
+writeFileSync(targetPath, updated, 'utf-8')
+const slug = targetFile.replace(/\.(md|mdx)$/, '')
+console.log(`Shortlink "${code}" → /events/${slug} (${targetFile})`)

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -58,6 +58,13 @@ const createEventSchema = ({ image }: SchemaContext) =>
       })
       .optional(),
     noindex: z.boolean().optional().default(false),
+    shortlink: z
+      .string()
+      .regex(
+        /^[a-z0-9]{3}$/,
+        'shortlink muss aus genau 3 Zeichen bestehen ([a-z0-9]).',
+      )
+      .optional(),
   })
 const eventCollection = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/events' }),

--- a/src/content/events/2026-05-05-ki-workshop-dorf.md
+++ b/src/content/events/2026-05-05-ki-workshop-dorf.md
@@ -5,6 +5,7 @@ startDate: 2026-05-05T19:00:00+02:00
 endDate: 2026-05-05T20:30:00+02:00
 location: dgh
 organizer: levin-keller
+shortlink: nzs
 ---
 
 Am Dienstag, den 5. Mai, lädt Levin Keller ins Dorfgemeinschaftshaus zu einem Abend über Künstliche Intelligenz ein. Viele haben davon gehört, nutzen sie aber noch nicht selbst. An dem Abend gibt es eine kurze Einführung und danach Zeit, KI auf dem eigenen Smartphone oder Laptop auszuprobieren.

--- a/src/content/events/2026-05-05-ki-workshop-dorf.md
+++ b/src/content/events/2026-05-05-ki-workshop-dorf.md
@@ -5,7 +5,7 @@ startDate: 2026-05-05T19:00:00+02:00
 endDate: 2026-05-05T20:30:00+02:00
 location: dgh
 organizer: levin-keller
-shortlink: nzs
+shortlink: g7e
 ---
 
 Am Dienstag, den 5. Mai, lädt Levin Keller ins Dorfgemeinschaftshaus zu einem Abend über Künstliche Intelligenz ein. Viele haben davon gehört, nutzen sie aber noch nicht selbst. An dem Abend gibt es eine kurze Einführung und danach Zeit, KI auf dem eigenen Smartphone oder Laptop auszuprobieren.

--- a/src/integrations/event-shortlinks.ts
+++ b/src/integrations/event-shortlinks.ts
@@ -1,0 +1,52 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { AstroIntegration } from 'astro'
+
+const SHORTLINK_REGEX = /^shortlink:\s*([a-z0-9]{3})\s*$/m
+
+const eventShortlinks = (): AstroIntegration => ({
+  name: 'event-shortlinks',
+  hooks: {
+    'astro:build:done': ({ dir, logger }) => {
+      const eventsDir = join(process.cwd(), 'src/content/events')
+      const files = readdirSync(eventsDir).filter(
+        (f) => !f.startsWith('_') && (f.endsWith('.md') || f.endsWith('.mdx')),
+      )
+
+      const seen = new Map<string, string>()
+      const lines: string[] = []
+
+      for (const file of files) {
+        const raw = readFileSync(join(eventsDir, file), 'utf-8')
+        const match = raw.match(SHORTLINK_REGEX)
+        if (!match) continue
+        const code = match[1] as string
+        const previous = seen.get(code)
+        if (previous) {
+          throw new Error(
+            `Doppelter shortlink "${code}" in "${file}" und "${previous}". Shortlinks müssen eindeutig sein.`,
+          )
+        }
+        seen.set(code, file)
+        const slug = file.replace(/\.(md|mdx)$/, '')
+        lines.push(`/${code}\t/events/${slug}\t301`)
+      }
+
+      if (lines.length === 0) {
+        logger.info(
+          'Keine Event-Shortlinks gefunden, _redirects nicht geschrieben.',
+        )
+        return
+      }
+
+      const outPath = join(fileURLToPath(dir), '_redirects')
+      writeFileSync(outPath, `${lines.join('\n')}\n`, 'utf-8')
+      logger.info(
+        `${lines.length} Event-Shortlink(s) nach _redirects geschrieben.`,
+      )
+    },
+  },
+})
+
+export default eventShortlinks

--- a/src/tools/events/content-rules.test.ts
+++ b/src/tools/events/content-rules.test.ts
@@ -49,4 +49,24 @@ describe('Event-Content-Regeln', () => {
       }
     },
   )
+
+  test('shortlinks sind eindeutig und korrekt formatiert', () => {
+    const seen = new Map<string, string>()
+    for (const file of eventFiles) {
+      const { frontmatter } = parseEvent(join(EVENTS_DIR, file))
+      const match = frontmatter.match(/^shortlink:\s*(\S+)\s*$/m)
+      if (!match) continue
+      const value = match[1] ?? ''
+      expect(
+        value,
+        `Event "${file}" hat einen ungültigen shortlink "${value}". Erwartet werden genau 3 Zeichen aus [a-z0-9].`,
+      ).toMatch(/^[a-z0-9]{3}$/)
+      const previous = seen.get(value)
+      expect(
+        previous,
+        `Doppelter shortlink "${value}" in "${file}" und "${previous}". Shortlinks müssen eindeutig sein.`,
+      ).toBeUndefined()
+      seen.set(value, file)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
This PR introduces a shortlink system for events that enables short, memorable URLs (e.g., `/nzs`) to redirect to full event pages (e.g., `/events/2026-05-05-ki-workshop-dorf`). The system includes automatic shortlink generation, validation, and build-time redirect generation.

## Key Changes

- **New Script**: `scripts/assign-event-shortlink.js` - CLI tool to generate and assign unique 3-character shortlinks to event files
  - Generates random alphanumeric codes (a-z, 0-9)
  - Validates uniqueness across all events
  - Inserts shortlink into event frontmatter
  - Provides helpful error messages in German

- **New Integration**: `src/integrations/event-shortlinks.ts` - Astro integration that generates redirect rules
  - Reads shortlinks from event frontmatter during build
  - Validates uniqueness and detects duplicates
  - Generates `_redirects` file with 301 redirects for deployment platforms (Netlify, Vercel, etc.)

- **Schema Update**: Added optional `shortlink` field to event content schema
  - Validates format: exactly 3 characters from `[a-z0-9]`
  - Optional field to maintain backward compatibility

- **Test Coverage**: Added validation test in `src/tools/events/content-rules.test.ts`
  - Ensures all shortlinks match required format
  - Detects duplicate shortlinks across events

- **Configuration**: 
  - Registered new integration in `astro.config.mjs`
  - Added `shortlink` npm script for easy shortlink assignment

## Implementation Details

- Shortlinks are 3-character codes using lowercase letters and digits
- The system prevents collisions by tracking all assigned codes
- Shortlinks are optional to allow gradual adoption
- Build-time validation ensures data integrity
- Redirect format uses tab-separated values compatible with Netlify/Vercel `_redirects` files

https://claude.ai/code/session_0166bLFrpqqqAdCXSn6VBpjd