### PR TITLE
feat(events): Party auf dem Dorffest am 05.09.2026 hinzufügen

### DIFF
--- a/src/content/events/2026-09-05-dorffest-party.md
+++ b/src/content/events/2026-09-05-dorffest-party.md
@@ -1,0 +1,9 @@
+---
+startDate: 2026-09-05T18:00:00+02:00
+location: bolzplatz
+organizer: ortsrat
+description: Party im Rahmen des Dorffests Rössing auf dem Bolzplatz.
+name: Party auf dem Dorffest
+---
+
+Im Rahmen des Dorffests Rössing findet auf dem Bolzplatz eine Party statt. Beginn ist um 18:00 Uhr. Alle Rössingerinnen und Rössinger sowie Gäste sind herzlich eingeladen, gemeinsam zu feiern.

--- a/src/data/locations/bolzplatz.yaml
+++ b/src/data/locations/bolzplatz.yaml
@@ -1,0 +1,2 @@
+name: Bolzplatz Rössing
+'@type': Place


### PR DESCRIPTION
## Zusammenfassung

- Neues Event **„Party auf dem Dorffest"** am 05.09.2026 ab 18:00 Uhr im Rahmen des Dorffests Rössing (04.–06.09.2026).
- Veranstaltungsort: **Bolzplatz Rössing** – dafür neue Location `bolzplatz.yaml` angelegt, da bisher nicht vorhanden.
- Veranstalter: `ortsrat` (analog zum Dorffest-Hauptevent).

## Hinweise

- Adresse für die neue Bolzplatz-Location ist noch nicht hinterlegt – falls eine genaue Straßenadresse gewünscht ist, gerne nachreichen.
- Die `address`-Felder sind laut Schema optional, daher schema-konform.

## Test-Plan

- [x] `npm run format` läuft (keine neuen Warnungen durch diese Änderung)
- [x] `npx vitest run src/tools/events/` – alle 424 Tests grün
- [ ] Manuell prüfen, ob das Event in der Event-Liste / im Kalender korrekt am 05.09.2026 erscheint


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hsspzkzk6Ga6GhXc56b1CQ)_