### PR TITLE
fix: Konzert Dowland Beat Duddeck um 17 Uhr mit aktualisiertem Text

### DIFF
--- a/src/content/events/2026-06-28-konzert-kirche.md
+++ b/src/content/events/2026-06-28-konzert-kirche.md
@@ -1,10 +1,13 @@
 ---
-startDate: 2026-06-28
-allDay: true
+startDate: 2026-06-28T17:00:00+02:00
 location: kirche
 organizer: kirche
-description: 'Konzert "Dowland Beat Duddeck!" mit dem Ensemble Refresh in der St. Peter und Paul Kirche Rössing.'
+description: 'Crossover-Konzert im 400. Todesjahr John Dowlands mit Alter Musik, Lichtkunst und Deutscher Gebärdensprache. Eintritt frei, Spenden erbeten.'
 name: 'Konzert "Dowland Beat Duddeck!" – Ensemble Refresh'
 ---
 
-Das Ensemble Refresh gastiert mit dem Programm "Dowland Beat Duddeck!" in der St. Peter und Paul Kirche Rössing. Freuen Sie sich auf einen besonderen Konzertabend mit außergewöhnlicher Musik in der stimmungsvollen Atmosphäre der Kirche.
+Im 400. Todesjahr John Dowlands entwickelt das Ensemble refresh (Susanne Böhm, Beat Duddeck, Carsten Krüger, Christian Horn, Laura Frey, Andreas Düker) eine Crossover-Produktion, die Alte Musik, zeitgenössischen Ausdruck, Lichtkunst und Deutsche Gebärdensprache verbindet. Dowlands Lautenlieder – von zeitloser Melancholie – erklingen in besonderer Besetzung: Sopran, Altus, Bass, Barockgitarre, E-Gitarre, Chitarrone, Laute, Gambe und Bandoneón. So wird die historische Klangsprache erweitert, kulturelles Erbe bewahrt und neu interpretiert.
+
+Das Sextett refresh ist ein Ensemble an der Schnittstelle von Alter Musik, Gegenwartsästhetik und performativer Bildsprache. Seit seiner Gründung 2023 setzt es auf rare Klangfarben (Bandoneón, Viola da Gamba, Chitarrone, Barockgitarre, E-Gitarre neben den Singenden). Vertrautes scheint durch, wird wiedererkannt und klingt doch völlig neu. Refresh steht für mutige Neu-Kontexte: kammermusikalisch intim, visuell präzise, emotional direkt – Alte Musik im Jetzt.
+
+Am 28. Juni, um 17.00 Uhr, sind alle Interessierten zu einem Werkstattkonzert in der Peter und Paul Kirche in Rössing eingeladen. Der Eintritt ist frei, Spenden erbeten.


### PR DESCRIPTION
## Zusammenfassung
- Uhrzeit (17:00 Uhr) zum Konzert hinzugefügt
- Beschreibungstext aus Issue #214 übernommen

Closes #214

Generated with [Claude Code](https://claude.ai/code)