### PR TITLE
feat(events): Singen im Rudel – 7. Juni 2026

### DIFF
--- a/src/content/events/2026-06-07-singen-im-rudel-kulturoeffner.md
+++ b/src/content/events/2026-06-07-singen-im-rudel-kulturoeffner.md
@@ -1,0 +1,9 @@
+---
+name: Singen im Rudel
+description: Gemeinsames Karaoke-Singen für alle – herzlich willkommen!
+startDate: 2026-06-07T16:00:00+02:00
+location: hof-baumgarten
+organizer: kulturoeffner
+---
+
+Alle sind herzlich willkommen zum gemeinsamen Karaoke-Singen in der Scheune bei Ernst Baumgarten. Macht alle mit!


### PR DESCRIPTION
## Zusammenfassung

- Neues Event „Singen im Rudel" vom KulTürÖffner Rössing hinzugefügt
- Datum: 7. Juni 2026, 16:00 Uhr
- Ort: Scheune bei Ernst Baumgarten (Hof Baumgarten)
- Gemeinsames Karaoke-Singen, alle willkommen

## Testplan

- [ ] Event erscheint in der Veranstaltungsliste
- [ ] Datum und Uhrzeit korrekt dargestellt
- [ ] Organizer (KulTürÖffner) und Location (Hof Baumgarten) korrekt verknüpft

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJhHnaiK1ERfHxwGfBM9y9)_