### PR TITLE
fix(content): DEG als geplant statt als bestehend darstellen

### DIFF
--- a/src/pages/digitales-dorf.astro
+++ b/src/pages/digitales-dorf.astro
@@ -18,14 +18,14 @@ const bausteine = [
     subtitle: 'Ein Login für alle Dorf-Dienste',
     href: 'https://id.xn--rssing-wxa.de',
     status: 'live',
-    text: 'Ein einziges Konto für alle digitalen Angebote im Dorf – Vereine, Apps und Werkzeuge. Einmal anmelden, überall dabei. Betrieben von der Dorfentwicklungsgesellschaft (DEG).',
+    text: 'Ein einziges Konto für alle digitalen Angebote im Dorf – Vereine, Apps und Werkzeuge. Einmal anmelden, überall dabei. Betrieben von Levin Keller, bis eine Dorfentwicklungsgesellschaft (DEG) gegründet ist.',
   },
   {
     title: 'Digitales Dorfarchiv',
     subtitle: 'Rössings Geschichte bewahren',
     href: 'https://archiv.xn--rssing-wxa.de',
     status: 'live',
-    text: 'Historische Dokumente, Fotos und Berichte digital gesammelt und für kommende Generationen bewahrt. Jede und jeder kann mitmachen. Betrieben von der Dorfentwicklungsgesellschaft (DEG).',
+    text: 'Historische Dokumente, Fotos und Berichte digital gesammelt und für kommende Generationen bewahrt. Jede und jeder kann mitmachen. Betrieben von Levin Keller, bis eine Dorfentwicklungsgesellschaft (DEG) gegründet ist.',
   },
   {
     title: 'Geräte-Mietplattform',
@@ -124,15 +124,21 @@ const statusBadge: Record<string, string> = {
       </p>
       <ul>
         <li>
-          Die <strong>Dorfentwicklungsgesellschaft (DEG)</strong> betreibt
-          diese Website <a href="https://xn--rssing-wxa.de">rössing.de</a>, das
+          Diese Website <a href="https://xn--rssing-wxa.de">rössing.de</a>, das
           <a href="https://archiv.xn--rssing-wxa.de">digitale Dorfarchiv</a> und
-          die <a href="https://id.xn--rssing-wxa.de">Dorf-ID</a>.
+          die <a href="https://id.xn--rssing-wxa.de">Dorf-ID</a> betreibt
+          derzeit <strong>Levin Keller</strong> privat. Der Plan ist, diese
+          Dienste in eine <strong>Dorfentwicklungsgesellschaft (DEG)</strong>
+          zu überführen – die gibt es allerdings noch nicht. Sie soll gegründet
+          werden, sobald sich Mitstreiter:innen finden, die das gemeinsam
+          tragen wollen. Wer dabei sein möchte:
+          <a href="/about">meldet euch</a>.
         </li>
         <li>
           Die <strong>Ideenwerkstatt</strong> ist ein Angebot der
           <strong>KulTürÖffner Rössing</strong>, in dem Ideen für die Zukunft
-          des Dorfes zusammenkommen – nicht der DEG.
+          des Dorfes zusammenkommen – sie gehört nicht zu den oben genannten
+          Diensten.
         </li>
         <li>
           Alle weiteren Dienste werden eigenständig von den jeweiligen

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,8 @@ const vereine = [
   },
   {
     name: 'Dorfentwicklung',
-    description: 'Wie sich Rössing weiterentwickeln will – „Unser Dorf hat Zukunft“.',
+    description:
+      'Wie sich Rössing weiterentwickeln will – „Unser Dorf hat Zukunft“.',
     href: 'https://dorfentwicklung.xn--rssing-wxa.de',
   },
   {


### PR DESCRIPTION
## Worum geht es

Auf `/digitales-dorf` stand die Dorfentwicklungsgesellschaft (DEG) als bestehende Betreiberin – die gibt es aber noch gar nicht. Betrieben werden rössing.de, das digitale Dorfarchiv und die Dorf-ID derzeit privat von Levin Keller; die DEG soll gegründet werden, sobald sich Mitstreiter:innen finden.

## Änderungen

Alle drei DEG-Erwähnungen in `src/pages/digitales-dorf.astro` richtiggestellt:

- **Karten „Dorf-ID" und „Digitales Dorfarchiv"**: „Betrieben von der Dorfentwicklungsgesellschaft (DEG)." → „Betrieben von Levin Keller, bis eine Dorfentwicklungsgesellschaft (DEG) gegründet ist."
- **Abschnitt „Wer betreibt was?"**: Der erste Listenpunkt nennt jetzt Levin Keller als aktuellen Betreiber und beschreibt die DEG als Ziel, das noch Mitgründer:innen braucht – mit Verweis auf die Mitmachen-Seite.
- **Ideenwerkstatt**: Die Abgrenzung „nicht der DEG" ergab ohne existierende DEG keinen Sinn und lautet jetzt „gehört nicht zu den oben genannten Diensten".

Rein inhaltliche Änderung, keine Logik betroffen.

## Tests

- `npm run build` – erfolgreich, 242 Seiten, Shipyard-Linkcheck grün (3274 Links)
- `npm run format` – angewendet

Hinweis: `npm run check` meldet auf diesem Branch weiterhin den vorbestehenden Typfehler in `src/pages/events/[id].astro`; der Fix dafür steckt in #219.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRohrKMyy6ik4FVUPKy8tE)_